### PR TITLE
Add TypeScript definition for Guard, Gate and Bouncer

### DIFF
--- a/src/Bouncer/index.d.ts
+++ b/src/Bouncer/index.d.ts
@@ -1,0 +1,22 @@
+/// <reference path="../Gate/index.d.ts" />
+
+/**
+ * node-fence
+ * @license MIT
+ * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
+ */
+
+/**
+ * TypeScript Bouncer class definition
+ */
+declare class Bouncer {
+  constructor(user: object);
+
+  public goThroughGate(gate: string): this;
+  public pass(gate: string): this;
+  public for(resource: object | string): Gate;
+  public callPolicy(ability: string, resource: object): boolean;
+}
+
+export as namespace Bouncer;
+export = Bouncer;

--- a/src/Gate/index.d.ts
+++ b/src/Gate/index.d.ts
@@ -1,0 +1,16 @@
+/**
+ * node-fence
+ * @license MIT
+ * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
+ */
+
+/**
+ * TypeScript (Exported) Gate class definition
+ */
+declare class Gate {
+  public define(name: string, callback: Function| string): this;
+  public policy(resource: Function|object|string, policy: Function|object): this;
+}
+
+export as namespace Gate;
+export = new Gate();

--- a/src/Guard/index.d.ts
+++ b/src/Guard/index.d.ts
@@ -1,0 +1,20 @@
+/// <reference path="../Bouncer/index.d.ts" />
+
+/**
+ * node-fence
+ * @license MIT
+ * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
+ */
+
+/**
+ * TypeScript (Exported) Guard class definition
+ */
+declare class Guard {
+    public setDefaultUser(user: object): void;
+    public can(user: object): Bouncer;
+    public allows(ability: string, resource: object | string): boolean;
+    public denies(ability: string, resource: object | string): boolean;
+}
+
+export as namespace Guard;
+export = new Guard();

--- a/src/Guard/index.js
+++ b/src/Guard/index.js
@@ -30,7 +30,7 @@ class Guard {
    *
    * @method can
    * @param  {object} user
-   * @return {boolean}
+   * @return {Bouncer}
    */
   can (user) {
     return new Bouncer(user)


### PR DESCRIPTION
The pull-request implement three TypeScript definition that VS Code will use for intellisense type completion.

I include a little fix of the JSDoc where Gate.can return a boolean instead of a typeof Bouncer.

Best Regards,
Thomas